### PR TITLE
Removed notifier.username as not supported by slack_notifier

### DIFF
--- a/app/jobs/slack_job.rb
+++ b/app/jobs/slack_job.rb
@@ -12,7 +12,6 @@ class SlackJob < ActiveJob::Base
 
     # Send Ping
     notifier = Slack::Notifier.new AppSettings['slack.post_url']
-    notifier.username = "HelpyBot"
     notifier.ping title, attachments: [message], channel: AppSettings['slack.default_channel']
   end
 end


### PR DESCRIPTION
slack-notifier throws "NoMethodError undefined method `username='" and therefore slack notifications fail. Removing notifier.username fixes this and notifications are successfully sent.